### PR TITLE
Maintenance script for updating models

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,27 +28,49 @@ Hosted on Google App Engine.
 
 ## Running locally
 Install Python packages with  
-```
+```bash
 pip install -r requirements.txt
 ```  
 Then, run in localhost with
-```
+```bash
 python main.py
 ```
 
+Maitenance requests for training new models can be tested locally by settings required headers with something like:
+```bash
+curl 127.0.0.1:5000/_parse_descriptions -H "X-Appengine-Cron: 1"
+```
+for parsing a new batch of game descriptions from Steam Store, and
+```bash
+curl 127.0.0.1:5000/_train -H "X-Appengine-Cron: 1"
+```
+For training new models (but see also below).
+
+### Adding new models
+The script `setup_gcs_models.py` can be run locally, without Flask application context, to save model changes to the Cloud Storage bucket.
+While the `/_train` endpoint performs the same action, it is mainly intended for periodically re-training existing models. The
+Flask application assumes all listed models are present in the storage bucket at all times.
+
+When adding new models, run the following to update the model files in the production bucket:
+```bash
+python setup_gcs_models.py --env prod
+```
+
+
 ## Unit tests
 Unit tests can be run from the root folder with
-```
+```bash
 pytest
 ```
 
 ## Deploy to Google App Engine
 To deploy as an App Engine service, install the [gcloud CLI tool](https://cloud.google.com/sdk/gcloud) and run
-```
+```bash
 gcloud app deploy
 ```
 This does not deploy scheduling from `cron.yaml`. To do that, run
-```
+```bash
 gcloud app deploy cron.yaml
 ```
-Note that scheduling is App Engine specific and will overwerite any existing scheduling.
+
+> **_NOTE:_**  App Engine scheduling applies at the application level; this will overwrite any existing scheduling for all other services.

--- a/main.py
+++ b/main.py
@@ -8,8 +8,8 @@ from flask import (
     abort
 )
 
-from src import generate_description, parser, utils
-from src.generator import trainer
+from src import generate_description, parser
+import setup_gcs_models
 
 
 
@@ -43,20 +43,7 @@ def train_model():
     # (The X- headers are stripped by App Engine when they originate from external sources)
     # https://cloud.google.com/appengine/docs/standard/python3/scheduling-jobs-with-cron-yaml#validating_cron_requests
     if "X-Appengine-Cron" in request.headers:
-        logging.info("Creating a new description model")
-        description_text = utils.download_descriptions_as_text()
-        t = trainer.Trainer(description_text, "model.pkl")
-        t.run()
-
-        logging.info("Creating a new title model")
-        names_text = parser.get_app_names()
-        t = trainer.Trainer(names_text, "model_titles.pkl", 2)
-        t.run()
-
-        logging.info("Creating a new feature model")
-        feature_text = utils.get_text_file("data/features.txt")
-        t = trainer.Trainer(feature_text, "model_features.pkl")
-        t.run()
+        setup_gcs_models.setup()
 
         return "OK\n", 200
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ gunicorn
 markdown
 pytest
 python-dotenv
+pyyaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,6 +43,7 @@ Pygments==2.12.0
 pyparsing==3.0.9
 pytest==7.1.2
 python-dotenv==1.0.0
+PyYAML==6.0.1
 requests==2.28.1
 rsa==4.9
 six==1.16.0

--- a/setup_gcs_models.py
+++ b/setup_gcs_models.py
@@ -1,0 +1,63 @@
+# Contains a setup function for creating new models and saving them to the remote bucket.
+# Useful for manually adding any new models as the Flask app expects all models to be present
+# at all times.
+#
+# To update production buckets run with
+# python setup_gcs_models.py --env prod
+
+
+
+import argparse
+import logging
+import os
+from importlib import reload
+
+import yaml
+
+from src import parser, utils
+from src.generator import trainer
+
+
+
+logging.basicConfig(format="%(asctime)s %(message)s", level=logging.INFO)
+
+
+def setup():
+    """Train new generator models and store in Cloud Storage bucket.
+    Existing models will be overwritten.
+    """
+    logging.info("Creating a new description model...")
+    description_text = utils.download_descriptions_as_text()
+    t = trainer.Trainer(description_text, "model.pkl")
+    t.run()
+
+    logging.info("Creating a new title model...")
+    names_text = parser.get_app_names()
+    t = trainer.Trainer(names_text, "model_titles.pkl", 2)
+    t.run()
+
+    logging.info("Creating a new feature model...")
+    feature_text = utils.get_text_file("data/features.txt")
+    t = trainer.Trainer(feature_text, "model_features.pkl")
+    t.run()
+
+    logging.info("Models saved in gs://%s", utils.MODEL_BUCKET)
+    
+
+if __name__ == "__main__":
+    argparser = argparse.ArgumentParser()
+    argparser.add_argument("--env", nargs="?", help="environment for storing results")
+    args = argparser.parse_args()
+
+    if args.env == "prod":
+        logging.info("Using production bucket config!")
+
+        # Load production buckets from the app config
+        with open("app.yaml") as f:
+            data = yaml.safe_load(f)
+            os.environ.update(data["env_variables"])
+            
+        # Reload module to propagate bucket name changes to helper functions
+        reload(utils)
+
+    setup()

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,6 +1,6 @@
+import logging
 import os
 import os.path
-import json
 
 from google.cloud import storage
 
@@ -26,13 +26,18 @@ def download_from_gcs(bucket, path):
 
 def download_descriptions_as_text():
 	"""Download all descriptions currently in temp bucket."""
-	blobs = gcs_client.list_blobs(TEMP_BUCKET, prefix="steam_game_descriptor/descriptions")
+	prefix = "steam_game_descriptor/descriptions"
+	blobs = gcs_client.list_blobs(TEMP_BUCKET, prefix=prefix)
 	results = []
 
+	count = 0
 	for blob in blobs:
+		count += 1
 		data_string = blob.download_as_bytes().decode("utf8")
 		results.append(data_string)
 	
+	logging.info("Loaded %d descriptions from gs://%s/%s", count, TEMP_BUCKET, prefix)
+
 	return " ".join(results)
 
 def get_text_file(filename):


### PR DESCRIPTION
Add a dedicated script for (re-)training models and saving to the remote bucket.

Using the `/_train` endpoint will fail if all model files are not already present in the bucket.