### PR TITLE
Handle empty successors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 .pytest_cache/
+.vscode/
 venv/

--- a/README.md
+++ b/README.md
@@ -50,11 +50,17 @@ flask -e .env.prod --app main:app run --debug
 ```
 
 ### Updating models
-The script `setup_gcs_models.py` can be run locally, without Flask application context, to save model changes to the Cloud Storage bucket.
-While the `/_train` endpoint performs the same action, it is mainly intended for periodically re-training production models. The
-Flask application assumes all listed models are present in the storage bucket at all times.
+The script `setup_gcs_models.py` can be run locally, without Flask application context, to apply model changes
+to the Cloud Storage bucket for development purposes.
+While the `/_train` endpoint performs the same action, it is mainly intended for periodically re-training
+existing production models.
 
-When adding new models, run the following to update the model files in the production bucket:
+To update the models, run
+```bash
+python -m src.setup_gcs_models
+```
+
+To override the default dev environment, run
 ```bash
 dotenv -f .env.prod run python -m src.setup_gcs_models
 ```

--- a/src/generator/generator.py
+++ b/src/generator/generator.py
@@ -92,9 +92,13 @@ class Generator:
 		Return
 			a randomly chosen word
 		"""
+		if not self.model[self._key]:
+			logger.warning("No successor for %s. Choosing a new seed.", self._key)
+			self._key = random.choice(list(self.model))
+
 		next_word = random.choice(list(self.model[self._key]))
 
-		# Update current key: shift to the right once and add the new word
+		# Update current key: shift to the right once and add the chosen word
 		self._key = (*self._key[1:], next_word)
 
 		return next_word

--- a/src/generator/trainer.py
+++ b/src/generator/trainer.py
@@ -59,7 +59,7 @@ class Trainer():
 			[What, a, lovely], and
 			[a, lovely, day]
 		Return:
-			a generator yielding the ngrams
+			a generator yielding the ngrams as list of length n
 		"""
 		train_data = self.train_text_data.split()
 		if len(train_data) < self.n:
@@ -78,6 +78,9 @@ class Trainer():
 		degrees = [ len(self.model_data[key]) for key in self.model_data ]
 		median = statistics.median(degrees)
 		units = degrees.count(1) / len(degrees)
+		empty = degrees.count(0)
 		mb_size = sys.getsizeof(self.model_data) / 10**6
 
 		logger.info("Model statistics: median degree: %s, unit ngram rate: %.2f, size: %.2fMB", median, units, mb_size)
+		if empty:
+			logging.warning("Detected %d keys wihtout successors", empty)

--- a/src/generator/trainer.py
+++ b/src/generator/trainer.py
@@ -28,7 +28,7 @@ class Trainer():
 		self.n = n
 		self.train_text_data = train_text_data
 		self.filename = filename
-		self.model_data = None
+		self.model = None
 
 	def run(self):
 		"""Train a new model and upload to data bucket."""
@@ -38,7 +38,7 @@ class Trainer():
 		self.train()
 		self.compute_statistics()
 
-		model = pickle.dumps(self.model_data)
+		model = pickle.dumps(self.model)
 		utils.upload_to_gcs(model, utils.MODEL_BUCKET, "models/" + self.filename)
 
 	def train(self):
@@ -51,7 +51,7 @@ class Trainer():
 			key = tuple(ngram[:-1])  # convert to tuple for a hashable dictionary key
 			data[key].add(ngram[-1])
 
-		self.model_data = data
+		self.model = data
 
 	def create_ngrams(self):
 		"""Generator for creating ngrams from the training data. For instance,
@@ -75,11 +75,11 @@ class Trainer():
 		 * unit ngram rate: the % of keys having degree 1
 		 * size in megabytes
 		"""
-		degrees = [ len(self.model_data[key]) for key in self.model_data ]
+		degrees = [ len(self.model[key]) for key in self.model ]
 		median = statistics.median(degrees)
 		units = degrees.count(1) / len(degrees)
 		empty = degrees.count(0)
-		mb_size = sys.getsizeof(self.model_data) / 10**6
+		mb_size = sys.getsizeof(self.model) / 10**6
 
 		logger.info("Model statistics: median degree: %s, unit ngram rate: %.2f, size: %.2fMB", median, units, mb_size)
 		if empty:

--- a/src/generator/trainer.py
+++ b/src/generator/trainer.py
@@ -32,6 +32,9 @@ class Trainer():
 
 	def run(self):
 		"""Train a new model and upload to data bucket."""
+		if len(self.train_text_data) < 100:
+			raise RuntimeError("Cannot train a model with source data of length < 100")
+
 		self.train()
 		self.compute_statistics()
 
@@ -60,7 +63,7 @@ class Trainer():
 		"""
 		train_data = self.train_text_data.split()
 		if len(train_data) < self.n:
-			return
+			raise RuntimeError(f"Not enough words to split; received {len(train_data)}, need {self.n}")
 
 		# Yield each ngram
 		for i in range(len(train_data) - (self.n - 1)):
@@ -72,11 +75,7 @@ class Trainer():
 		 * unit ngram rate: the % of keys having degree 1
 		 * size in megabytes
 		"""
-		degrees = []
-		for key in self.model_data:
-			d = len(self.model_data[key])
-			degrees.append(d)
-
+		degrees = [ len(self.model_data[key]) for key in self.model_data ]
 		median = statistics.median(degrees)
 		units = degrees.count(1) / len(degrees)
 		mb_size = sys.getsizeof(self.model_data) / 10**6

--- a/src/parser.py
+++ b/src/parser.py
@@ -116,11 +116,10 @@ def get_app_names(batch_size=100_000):
 	"""
 	r = requests.get("https://api.steampowered.com/ISteamApps/GetAppList/v2")
 	app_list = r.json()["applist"]["apps"]
-	# Assert at least one ASCII chracter in the name
 
 	# Filter results:
-	# * at least 1 uppercase ASCII character
 	# * ignore some test apps
+	# * ignore titles without any uppercase ascii characters 
 	names = [
 		app["name"]
 		for app in app_list
@@ -128,7 +127,7 @@ def get_app_names(batch_size=100_000):
 			not app["name"].lower().endswith("playtest")
 			and "valvetestapp" not in app["name"].lower()
 			and app["name"] not in ("test", "test2", "test3")
-			and any(c in app["name"] for c in string.ascii_uppercase)
+			and set(app["name"]) & set(string.ascii_uppercase)
 		)
 	]
 

--- a/src/setup_gcs_models.py
+++ b/src/setup_gcs_models.py
@@ -1,6 +1,5 @@
 # Contains a setup function for creating new models and saving them to the remote bucket.
-# Useful for manually adding any new models as the Flask application expects all models to be present
-# at all times.
+# Useful for manually updating production models without a deployment context.
 #
 # To update production buckets run with
 # dotenv -f .env.prod run python -m src.setup_gcs_models.py 

--- a/test/test_generator.py
+++ b/test/test_generator.py
@@ -10,8 +10,14 @@ with patch("google.cloud.storage.Client"):
 @pytest.mark.parametrize(
     "input_key,expected_word,expected_output_key",
     [
-        (("If", "you"), "can", ("you", "can")),
-        (("which", "grain"), "will", ("grain", "will"))
+        (
+            ("If", "you"),
+            "can", ("you", "can")
+        ),
+        (
+            ("which", "grain"),
+            "will", ("grain", "will")
+        )
     ]
 )
 def test_next_word_selection(input_key, expected_word, expected_output_key):
@@ -49,7 +55,7 @@ def test_next_word_selection(input_key, expected_word, expected_output_key):
 
 @patch("src.generator.generator.Generator.get_word")
 def test_valid_seed(mock_get_word):
-    """Test generation with valid seed."""
+    """Test generation with a valid seed."""
     with patch("src.generator.generator.Generator._load_model") as mock_load_model:
         mock_load_model.return_value = {
             ('If', 'you'): ['can'],

--- a/test/test_trainer.py
+++ b/test/test_trainer.py
@@ -23,7 +23,7 @@ def test_model_train():
         ("and", "hope"): {"to"},
         ("hope", "to"): {"die"}
     }
-    assert t.model_data == expected
+    assert t.model == expected
 
 def test_model_on_duplicate_successors():
     """Test model train with duplicate ngrams."""
@@ -38,4 +38,4 @@ def test_model_on_duplicate_successors():
         ("too", "cold."): {"almost"},
         ("cold.", "almost"): {"too"}
     }
-    assert t.model_data == expected
+    assert t.model == expected


### PR DESCRIPTION
Fix a crash when an empty successor word list encountered on text generation. Choose a random key to continue generation.

fix #10 

## Misc
 * set a minimum length for training data
 * use a fixed size of Steam app names for title model
   * exclude some known test apps 