### PR TITLE
Minimize spacy tokenization

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -26,4 +26,6 @@ BASE = os.path.dirname(__file__)
 load_dotenv(".env.dev")
 
 # Load a pre-trained Spacy language model.
-nlp = spacy.load("en_core_web_md")
+# Disable specific pipeline component to speedup similarity inference 
+# https://spacy.io/usage/processing-pipelines#pipelines
+nlp = spacy.load("en_core_web_md", exclude=["ner", "parser"])

--- a/app/generator/generator.py
+++ b/app/generator/generator.py
@@ -23,6 +23,7 @@ class Generator:
 
 	def _load_model(self, name):
 		model_data = utils.download_from_gcs(utils.MODEL_BUCKET, "models/" + name)
+		logger.info("Loaded model %s from %s", name, utils.MODEL_BUCKET)
 		return pickle.loads(model_data)
 
 	def generate(

--- a/app/utils.py
+++ b/app/utils.py
@@ -134,14 +134,21 @@ def select_tags():
 
 def get_closest_word_match(context, choices):
     """Find the word in a list of choices that is semantically closest 
-    to key.
+    to it.
     Args:
         context (str): the word to find a match for
         choices (list): the list to look for the match
     Return:
         the matching word.
     """
-    return sorted(choices, key=lambda x: nlp(context).similarity(nlp(x)))[-1]
+    # Define a custom sort function; set an arbitrary fixed
+    # value for short words to save nlp inference delay.
+    def _similarity_key(item):
+        if len(item) < 4:
+            return -5
+        return nlp(context).similarity(nlp(item))
+
+    return sorted(choices, key=_similarity_key)[-1]
 
 def get_openai_secret():
     """Fetch OpenAI API key from Secret Manager."""


### PR DESCRIPTION
Minimize `spacy` calls to reduce frontend load times:
 - do not tokenize short words on context similarity detection
 - do not load `space` pipeline components not used 