### PR TITLE
Use data bucket for training data

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,4 +1,4 @@
-MODEL_BUCKET=dev_steam_game_descriptor_data
-TEMP_BUCKET=dev_temp_lf345f
-TEMP_BUCKET_PREFIX=steam_game_descriptor/v2/descriptions
+DATA_BUCKET=dev_steam_game_descriptor_data
+TRAINING_DATA_PREFIX=train/
+MODEL_PREFIX=models/
 IMG_BUCKET=dev_steam_game_descriptor_img

--- a/.env.prod
+++ b/.env.prod
@@ -1,4 +1,4 @@
-MODEL_BUCKET=prod_steam_game_descriptor_data
-TEMP_BUCKET=prod_temp_lf345f
-TEMP_BUCKET_PREFIX=steam_game_descriptor/v2/descriptions
+DATA_BUCKET=prod_steam_game_descriptor_data
+TRAINING_DATA_PREFIX=train/
+MODEL_PREFIX=models/
 IMG_BUCKET=prod_steam_game_descriptor_img

--- a/app.yaml
+++ b/app.yaml
@@ -8,7 +8,7 @@ automatic_scaling:
   max_instances: 3
 
 env_variables:
-  MODEL_BUCKET: prod_steam_game_descriptor_data
-  TEMP_BUCKET: prod_temp_lf345f
-  TEMP_BUCKET_PREFIX: steam_game_descriptor/v2/descriptions
+  DATA_BUCKET: prod_steam_game_descriptor_data
+  TRAINING_DATA_PREFIX: train/
+  MODEL_PREFIX: models/
   IMG_BUCKET: prod_steam_game_descriptor_img

--- a/app/generator/trainer.py
+++ b/app/generator/trainer.py
@@ -43,7 +43,7 @@ class Trainer():
 		self.compute_statistics()
 
 		model = pickle.dumps(self.model)
-		gcs.upload_to_gcs(model, gcs.MODEL_BUCKET, "models/" + self.filename)
+		gcs.upload_to_gcs(model, gcs.DATA_BUCKET, gcs.MODEL_PREFIX + self.filename)
 
 	def train(self):
 		"""Train the model with the input text.

--- a/app/parser.py
+++ b/app/parser.py
@@ -42,8 +42,6 @@ def upload_description_batch(batch_size=200):
 	"""
 	app_id_batch = get_app_id_batch(batch_size)
 
-	TEMP_BUCKET_PREFIX = os.environ["TEMP_BUCKET_PREFIX"]
-
 	logger.info("Parsing %s descriptions", batch_size)
 	with requests.Session() as s:
 		s.params = {"cc": "us", "l": "english"}
@@ -77,10 +75,10 @@ def upload_description_batch(batch_size=200):
 			snapshot = format_data_dict(data)
 			ds = datetime.today().strftime("%Y-%m-%d")
 			name = data["name"].replace("/", "-") # Replace / to avoid issues with Cloud Storage prefixes
-			path = f"{TEMP_BUCKET_PREFIX}/{ds}/{name}.json"
+			path = f"{gcs.TRAINING_DATA_PREFIX}/{ds}/{name}.json"
 			gcs.upload_to_gcs(
 				json.dumps(snapshot, cls=json_set_encoder.SetEncoder),
-				gcs.TEMP_BUCKET,
+				gcs.DATA_BUCKET,
 				path,
 				content_type="application/json",
 			)
@@ -89,8 +87,8 @@ def upload_description_batch(batch_size=200):
 	logger.info(
 		"Succesfully uploaded %s descriptions to %s/%s",
 		success,
-		gcs.TEMP_BUCKET,
-		TEMP_BUCKET_PREFIX,
+		gcs.DATA_BUCKET,
+		gcs.TRAINING_DATA_PREFIX,
 	)
 
 def get_app_id_batch(batch_size):

--- a/app/parser.py
+++ b/app/parser.py
@@ -75,7 +75,7 @@ def upload_description_batch(batch_size=200):
 			snapshot = format_data_dict(data)
 			ds = datetime.today().strftime("%Y-%m-%d")
 			name = data["name"].replace("/", "-") # Replace / to avoid issues with Cloud Storage prefixes
-			path = f"{gcs.TRAINING_DATA_PREFIX}/{ds}/{name}.json"
+			path = f"{gcs.TRAINING_DATA_PREFIX}{ds}/{name}.json"
 			gcs.upload_to_gcs(
 				json.dumps(snapshot, cls=json_set_encoder.SetEncoder),
 				gcs.DATA_BUCKET,

--- a/app/setup_gcs_models.py
+++ b/app/setup_gcs_models.py
@@ -54,7 +54,7 @@ def setup():
     t = trainer.Trainer(ratings_text, "ratings.pkl")
     t.run()
 
-    logger.info("Models saved in gs://%s", utils.gcs.MODEL_BUCKET)
+    logger.info("Models saved in gs://%s", utils.gcs.DATA_BUCKET)
 
 def _merge_requirements(source_data_list):
     """Merge a list of requirement dicts.


### PR DESCRIPTION
Move training data from common project wide temp bucket to a new prefix on the dedicated data bucket.

Existing training data files moved manually.